### PR TITLE
Update Debian image

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -15,7 +15,7 @@ jobs:
         features:
           - rojo
         baseImage:
-          # - debian:latest
+          - debian:trixie
           - ubuntu:latest
           - mcr.microsoft.com/devcontainers/base:ubuntu
     steps:

--- a/src/rojo/NOTES.md
+++ b/src/rojo/NOTES.md
@@ -1,7 +1,7 @@
 
 ## OS Support
 
-This Feature should work on recent versions of Debian/Ubuntu-based distributions with the `apt` package manager installed.
+This Feature should work on recent versions of Debian/Ubuntu-based distributions with the `apt` package manager installed. Debian `trixie` (or `debian-13`) or later is required because of the `GLIBC_2.39` requirement for Rojo.
 
 `bash` is required to execute the `install.sh` script.
 

--- a/src/rojo/NOTES.md
+++ b/src/rojo/NOTES.md
@@ -1,9 +1,8 @@
 
-
 ## OS Support
 
 This Feature should work on recent versions of Debian/Ubuntu-based distributions with the `apt` package manager installed.
 
 `bash` is required to execute the `install.sh` script.
 
-`GLIBC_2.33`, `GLIBC_2.32`, or `GLIBC_2.34` are required to install [Aftman](https://github.com/LPGhatguy/aftman) and [Rokit](https://github.com/rojo-rbx/rokit).
+`GLIBC_2.33`, `GLIBC_2.32`, or `GLIBC_2.34` are required to install [Aftman](https://github.com/LPGhatguy/aftman) and [Rokit](https://github.com/rojo-rbx/rokit). `GLIBC_2.39` is required to install [Rojo](https://github.com/rojo-rbx/rojo).


### PR DESCRIPTION
## Description

Updates tests to use Debian `trixie` instead of `latest` which is `bookworm`. Debian `bookworm` doesn't work for Rojo because of `GLIBC_2.39` so we need to use a newer version that works with it.

## Related Issues

<!-- List any related issues or pull requests that are being resolved or addressed by this pull request.

Example:
Closes #issue_number

Replace issue_number with the issue number to mark it -->

## Changes Made

This pull request updates the base image for the development environment and modifies the documentation to reflect new system requirements for Rojo. The most important changes include switching to a specific Debian version in the workflow configuration and clarifying the required `GLIBC` version in the notes.

### Workflow configuration updates:
* [`.github/workflows/test.yaml`](diffhunk://#diff-245392b692a50c38ecab4381b118862db514035c10983f3bd4f4b7f1f4be4692L18-R18): Changed the base image from a commented-out `debian:latest` to `debian:trixie` to ensure compatibility with updated dependencies.

### Documentation updates:
* [`src/rojo/NOTES.md`](diffhunk://#diff-5898b1b6397e025be9e8423863f8a7e3474692f5e773f685a83c50ed1b595e63L2-R8): Updated the OS support section to specify that Debian `trixie` (or `debian-13`) or later is required due to the `GLIBC_2.39` requirement for Rojo. Also clarified that `GLIBC_2.39` is now required for installing Rojo.

## Checklist

<!-- Please check off the following items before submitting your pull request: 

Example:
- [x] I have checked this box

Simply put an "x" between the brackets like here to check it -->

- [x] I have tested these changes thoroughly.
- [x] I have reviewed my code for any potential errors or issues.
- [x] I have followed the code style guidelines for this project.

## Additional Notes

<!-- Provide any additional information or notes that may be helpful in reviewing this pull request. -->